### PR TITLE
Bug fixes and new options

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Environment configuration:
  * `FRPC_LOGFILE` - where to log status (log disabled if not set)
  * `FRPC_LOG_LEVEL` - level of logging, defaults to "warn"
  * `FRPC_LOG_DAYS` - log for how many days, defaults to 5 days
+ * `FRPC_ADMIN_ADDRESS` - (optional) admin server address, defaults to 127.0.0.1
+ * `FRPC_ADMIN_PORT` - (optional) admin server port, defaults to 7400
+ * `FRPC_ADMIN_USER` - (optional) admin server user credentials, if not set admin access is not established
+ * `FRPC_ADMIN_PWD` - (optional) admin server password credentials, if not set admin access is not established
 
 The container should be configured to have a read-only connection to the Docker process socket. It listens for changes in
 other containers and will reconfigure the FRP client if changes occur.
@@ -25,3 +29,6 @@ The `fpr.<port>` label should be set to either "tcp" or "http" to indicate the t
  * `fpr.<port>.http.rewrite` - rewrite Host when sending request to the proxied server
  * `fpr.<port>.http.username` - username for Basic HTTP authentication
  * `fpr.<port>.http.password` - password for Basic HTTP authentication
+
+Additionally, health check on ports can be disabled using:
+ * `frp.<port>.health_check=false` - disables port health check if no service is present at the port during the docker startup

--- a/etc/docker-gen.cfg
+++ b/etc/docker-gen.cfg
@@ -1,6 +1,6 @@
 [[config]]
 template = "/etc/frpc.ini.tpl"
 dest = "/etc/frpc.ini"
-notifycmd = "/usr/local/bin/frpc reload -c /etc/frpc.ini"
+notifycmd = "sleep 3 && sv restart frpc" # wait 3 sec to ensure docker will be fully loaded (so that healthcheck can pass)
 watch = true
 

--- a/etc/frpc.ini.tpl
+++ b/etc/frpc.ini.tpl
@@ -53,6 +53,8 @@ tls_enable = true
 {{ $rewrite := index $container.Labels (printf "frp.%s.http.rewrite" $address.Port) }}
 {{ $httpuser := index $container.Labels ( printf "frp.%s.http.username" $address.Port) }}
 {{ $httppwd := index $container.Labels ( printf "frp.%s.http.password" $address.Port) }}
+{{ $healthcheck := index $container.Labels ( printf "frp.%s.health_check" $address.Port) }}
+{{ $healthcheck := when ( or (or (eq $healthcheck "") (eq $healthcheck "true" )) (or (eq $healthcheck "True" ) (eq $healthcheck "1" )) )  true false }}
 
 {{ if $service_type }}
 
@@ -62,9 +64,11 @@ type = {{ $service_type }}
 local_ip = {{ $network.IP }}
 local_port = {{ $address.Port }}
 
+{{ if $healthcheck }}
 health_check_type = {{ $service_type }}
 health_check_timeout_s = 3
 health_check_interval_s = 60
+{{ end }}
 
 {{ if eq $service_type "http" }}
 

--- a/etc/frpc.ini.tpl
+++ b/etc/frpc.ini.tpl
@@ -64,9 +64,9 @@ health_check_type = {{ $service_type }}
 health_check_timeout_s = 3
 health_check_interval_s = 60
 
-{{ if (($service_type) eq "http") }}
+{{ if eq $service_type "http" }}
 
-{{ if ($httpuser) and ($httppwd) }}
+{{ if and $httpuser $httppwd }}
 http_user = {{ $httpuser }}
 http_pwd = {{ $httppwd }}
 {{ end }}

--- a/etc/frpc.ini.tpl
+++ b/etc/frpc.ini.tpl
@@ -15,11 +15,13 @@ log_max_days = {{ when (not .Env.FRPC_LOG_DAYS) "5" .Env.FRPC_LOG_DAYS }}
 
 token =  {{ when (not .Env.FRPC_AUTH_TOKEN) "abcdefghi" .Env.FRPC_AUTH_TOKEN }}
 
+{{if and .Env.FRPC_ADMIN_USER .Env.FRPC_ADMIN_PWD }}
 # set admin address for control frpc's action by http api such as reload (we do not expose this port)
-admin_addr = 127.0.0.1
-admin_port = 7400
-admin_user = admin
-admin_pwd = admin
+admin_addr = {{ when (not .Env.FRPC_ADMIN_ADDRESS) "127.0.0.1" .Env.FRPC_ADMIN_ADDRESS }}
+admin_port = {{ when (not .Env.FRPC_ADMIN_PORT) "7400" .Env.FRPC_ADMIN_PORT }}
+admin_user = {{ .Env.FRPC_ADMIN_USER }}
+admin_pwd = {{ .Env.FRPC_ADMIN_PWD }}
+{{end}}
 
 # connections will be established in advance, default value is zero
 pool_count = {{ when (not .Env.FRPC_POOL_COUNT) "5" .Env.FRPC_POOL_COUNT }}

--- a/etc/service/frpc/run
+++ b/etc/service/frpc/run
@@ -2,4 +2,9 @@
 
 sv start dockergen || exit 1
 
-exec /usr/local/bin/frpc -c /etc/frpc.ini 2>&1
+# if valid ADMIN user and passwd is set also reload the server
+if [ -z ${FRPC_ADMIN_USER}] || [-z ${FRPC_ADMIN_PWD}]; then
+  exec /usr/local/bin/frpc -c /etc/frpc.ini 2>&1
+else
+  exec /usr/local/bin/frpc reload -c /etc/frpc.ini 2>&1
+fi


### PR DESCRIPTION
Bug fixes:
 - fixed `/etc/frpc.ini.tpl` to correctly do `and` and `eq` operations in if clauses
 - changed notifycmd on `/etc/docker-gen.cfg` to do `sv restart frpc` instead of calling frpc directly
 - added 3 second delay to notifycmd in `/etc/docker-gen.cfg` to ensure that docker has a chance to setup before frpc will do health-check on ports

Other new options:
 - made ADMIN connection optional with new env variables (does frpc reload only if ADMIN credentials are set)
 - added `frp.<port>.health_check` container option to disable health-check if services are not yet active on ports