### PR TITLE
Added compatibility with LinkNotifer plugin 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ For HTTP connections the follwing configuration can be set:
 
  * `frp.<port>.http.subdomain` - a subdomain to use (the super-domain is set in FRP server configuration)
  * `frp.<port>.http.domains` - custom domains to use, comma separated
+ * `frp.<port>.http.locations` - locations to use, comma separated
  * `frp.<port>.http.rewrite` - rewrite Host when sending request to the proxied server
  * `frp.<port>.http.username` - username for Basic HTTP authentication
  * `frp.<port>.http.password` - password for Basic HTTP authentication

--- a/README.md
+++ b/README.md
@@ -40,3 +40,7 @@ For STCP (secret TCP) connections, the following configuration must be set:
 Additionally, health check on ports can be disabled using:
 
  * `frp.<port>.health_check=false` - disables port health check if no service is present at the port during the docker startup
+
+Optionally, email notification of the assigned ports can be actived (using LinkNotification plugin on FRP server) by setting:
+
+* `frp.notify_email` - set to email that will recieve notification of the assigned ports

--- a/etc/frpc.ini.tpl
+++ b/etc/frpc.ini.tpl
@@ -110,6 +110,7 @@ remote_port = 0
 {{ end }}
 
 meta_frpc_prefix = {{ $frpc_prefix }}
+meta_local_port = {{ $local_port }}
 {{ if  $notify_email }}
 meta_notify_email = {{ $notify_email }}
 {{ end }}

--- a/etc/frpc.ini.tpl
+++ b/etc/frpc.ini.tpl
@@ -110,7 +110,7 @@ remote_port = 0
 {{ end }}
 
 meta_frpc_prefix = {{ $frpc_prefix }}
-meta_local_port = {{ $address.Port | toDecimal }}
+meta_local_port = {{ $address.Port }}
 {{ if  $notify_email }}
 meta_notify_email = {{ $notify_email }}
 {{ end }}

--- a/etc/frpc.ini.tpl
+++ b/etc/frpc.ini.tpl
@@ -108,7 +108,10 @@ sk = {{ $secret_key }}
 # Allocate random free port
 remote_port = 0
 {{ end }}
+{{ end }}
 
+{{ if $notify_email }}
+# Provide metadata for notifier plugin
 meta_frpc_prefix = {{ $frpc_prefix }}
 meta_local_port = {{ $address.Port }}
 {{ if  $notify_email }}

--- a/etc/frpc.ini.tpl
+++ b/etc/frpc.ini.tpl
@@ -50,12 +50,12 @@ tls_enable = true
 {{ $encryption := index $container.Labels (printf "frp.%s.encryption" $address.Port) }}
 {{ $subdomain := index $container.Labels (printf "frp.%s.http.subdomain" $address.Port) }}
 {{ $domains := index $container.Labels (printf "frp.%s.http.domains" $address.Port) }}
+{{ $locations := index $container.Labels ( printf "frp.%s.http.locations" $address.Port) }}
 {{ $rewrite := index $container.Labels (printf "frp.%s.http.rewrite" $address.Port) }}
 {{ $httpuser := index $container.Labels ( printf "frp.%s.http.username" $address.Port) }}
 {{ $httppwd := index $container.Labels ( printf "frp.%s.http.password" $address.Port) }}
 {{ $healthcheck := index $container.Labels ( printf "frp.%s.health_check" $address.Port) }}
 {{ $healthcheck := when ( or (or (eq $healthcheck "") (eq $healthcheck "true" )) (or (eq $healthcheck "True" ) (eq $healthcheck "1" )) )  true false }}
-
 {{ if $service_type }}
 
 [{{ print $prefix "_" $name "_" $address.Port }}]
@@ -87,6 +87,10 @@ subdomain = {{ $subdomain }}
 
 {{ if $domains }}
 custom_domains = {{ $domains }}
+{{ end }}
+
+{{ if $locations }}
+locations = {{ $locations }}
 {{ end }}
 
 {{ if $rewrite }}

--- a/etc/frpc.ini.tpl
+++ b/etc/frpc.ini.tpl
@@ -45,10 +45,6 @@ tls_enable = true
 {{ $id := $container.ID }}
 {{ $notify_email := index $container.Labels (printf "frp.notify_email") }} 
 
-{{ if  $notify_email }}
-{{ $frpc_prefix := (print $notify_email "##" $frpc_prefix) }}
-{{ end }}
-
 {{ range $address := $container.Addresses }}
 {{ $service_type := index $container.Labels (printf "frp.%s" $address.Port) }}
 {{ $secret_key := index $container.Labels (printf "frp.%s.secret" $address.Port) }}
@@ -63,11 +59,7 @@ tls_enable = true
 {{ $healthcheck := when ( or (or (eq $healthcheck "") (eq $healthcheck "true" )) (or (eq $healthcheck "True" ) (eq $healthcheck "1" )) )  true false }}
 {{ if $service_type }}
 
-[{{ print $frpc_prefix "##" $name "##" $address.Port }}]
-
-{{ if  $notify_email }}
-meta_notify_email = {{ $notify_email }}
-{{ end }}
+[{{ print $frpc_prefix "_" $name "_" $address.Port }}]
 
 type = {{ $service_type }}
 local_ip = {{ $network.IP }}
@@ -116,6 +108,12 @@ sk = {{ $secret_key }}
 # Allocate random free port
 remote_port = 0
 {{ end }}
+
+meta_frpc_prefix = {{ $frpc_prefix }}
+{{ if  $notify_email }}
+meta_notify_email = {{ $notify_email }}
+{{ end }}
+
 {{ end }}
 
 {{ end }}

--- a/etc/frpc.ini.tpl
+++ b/etc/frpc.ini.tpl
@@ -31,7 +31,7 @@ login_fail_exit = false
 
 tls_enable = true
 
-{{ $prefix := when (not .Env.FRPC_PREFIX) "frp" .Env.FRPC_PREFIX }}
+{{ $frpc_prefix := when (not .Env.FRPC_PREFIX) "frp" .Env.FRPC_PREFIX }}
 
 {{ $work_network := when (not .Env.FRPC_NETWORK) "default" .Env.FRPC_NETWORK }}
 
@@ -43,6 +43,11 @@ tls_enable = true
 
 {{ $name := $container.Name }}
 {{ $id := $container.ID }}
+{{ $notify_email := index $container.Labels (printf "frp.notify_email") }} 
+
+{{ if  $notify_email }}
+{{ $frpc_prefix := (print $notify_email "##" $frpc_prefix) }}
+{{ end }}
 
 {{ range $address := $container.Addresses }}
 {{ $service_type := index $container.Labels (printf "frp.%s" $address.Port) }}
@@ -58,7 +63,11 @@ tls_enable = true
 {{ $healthcheck := when ( or (or (eq $healthcheck "") (eq $healthcheck "true" )) (or (eq $healthcheck "True" ) (eq $healthcheck "1" )) )  true false }}
 {{ if $service_type }}
 
-[{{ print $prefix "_" $name "_" $address.Port }}]
+[{{ print $frpc_prefix "##" $name "##" $address.Port }}]
+
+{{ if  $notify_email }}
+meta_notify_email = {{ $notify_email }}
+{{ end }}
 
 type = {{ $service_type }}
 local_ip = {{ $network.IP }}

--- a/etc/frpc.ini.tpl
+++ b/etc/frpc.ini.tpl
@@ -110,7 +110,7 @@ remote_port = 0
 {{ end }}
 
 meta_frpc_prefix = {{ $frpc_prefix }}
-meta_local_port = {{ $local_port }}
+meta_local_port = {{ $address.Port }}
 {{ if  $notify_email }}
 meta_notify_email = {{ $notify_email }}
 {{ end }}

--- a/etc/frpc.ini.tpl
+++ b/etc/frpc.ini.tpl
@@ -110,7 +110,7 @@ remote_port = 0
 {{ end }}
 
 meta_frpc_prefix = {{ $frpc_prefix }}
-meta_local_port = {{ $address.Port }}
+meta_local_port = {{ $address.Port | toDecimal }}
 {{ if  $notify_email }}
 meta_notify_email = {{ $notify_email }}
 {{ end }}


### PR DESCRIPTION
Added compatibility with the LinkNotifier plugin from https://github.com/skokec/docker-fprc. Notification can be enabled with "frp.notify_email" docker label, which will add several meta data to frpc.ini for each connection.